### PR TITLE
Add launch script for single-command startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,13 @@ cd Claude-Code-Communication
 ```
 これでバックグラウンドに5つのターミナル画面が準備されます！
 
+#### 💡 ワンコマンドで全て起動したい場合
+```bash
+./launch_all.sh claude   # 例: Claude Code を使用
+# ./launch_all.sh gemini  # Gemini CLI を使う場合
+```
+このコマンドは `setup.sh` と `start_agents.sh` をまとめて実行します。
+
 #### 3️⃣ セッションに接続（1分）
 
 **社長画面を開く：**
@@ -50,6 +57,7 @@ tmux attach-session -t president
 ./start_agents.sh claude   # 例: Claude Code を使用
 ./start_agents.sh gemini   # 例: Gemini CLI を使用
 ```
+※ `launch_all.sh` を使った場合はこのステップを飛ばして構いません。
 
 #### 5️⃣ 部下たちの画面を確認
 ・各画面で選択したCLIの認証が必要な場合あり

--- a/launch_all.sh
+++ b/launch_all.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# 環境セットアップとエージェント起動を一括実行するスクリプト
+# 使用方法: ./launch_all.sh [claude|gemini]
+
+CMD=${1:-claude}
+
+if [[ "$CMD" != "claude" && "$CMD" != "gemini" ]]; then
+  echo "Usage: $0 [claude|gemini]" >&2
+  exit 1
+fi
+
+# セットアップ
+./setup.sh || { echo "setup failed" >&2; exit 1; }
+
+# エージェント一括起動
+./start_agents.sh "$CMD"


### PR DESCRIPTION
## Summary
- add `launch_all.sh` to run setup and start agents at once
- document new script and usage in README

## Testing
- `shellcheck start_agents.sh setup.sh agent-send.sh launch_all.sh` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f40ccf5dc832ebe05b755d848fab0