### PR TITLE
fix gemini communication

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,10 @@ tmux attach-session -t president
 ```
 ※ `launch_all.sh` を使った場合はこのステップを飛ばして構いません。
 
+CLI は `.cli_mode` ファイルに記録され、`agent-send.sh` が自動的に読み取ります。
+Gemini CLI の場合は Ctrl+C を送信しない仕様になり、president → boss1 の
+指示が正常に通ります。
+
 #### 5️⃣ 部下たちの画面を確認
 ・各画面で選択したCLIの認証が必要な場合あり
 ```bash

--- a/agent-send.sh
+++ b/agent-send.sh
@@ -2,6 +2,9 @@
 
 # 🚀 Agent間メッセージ送信スクリプト
 
+# 使用中のCLIを判定 (claude または gemini)
+CLI_MODE=$(cat .cli_mode 2>/dev/null || echo "claude")
+
 # エージェント→tmuxターゲット マッピング
 get_agent_target() {
     case "$1" in
@@ -63,10 +66,12 @@ send_message() {
     local message="$2"
     
     echo "📤 送信中: $target ← '$message'"
-    
-    # Claude Codeのプロンプトを一度クリア
-    tmux send-keys -t "$target" C-c
-    sleep 0.3
+
+    # Claude Codeは生成中にCtrl-Cで停止できるが、Geminiはプロセス終了してしまう
+    if [[ "$CLI_MODE" == "claude" ]]; then
+        tmux send-keys -t "$target" C-c
+        sleep 0.3
+    fi
     
     # メッセージ送信
     tmux send-keys -t "$target" "$message"

--- a/start_agents.sh
+++ b/start_agents.sh
@@ -10,6 +10,9 @@ if [[ "$CMD" != "claude" && "$CMD" != "gemini" ]]; then
   exit 1
 fi
 
+# 現在使用しているCLIを記録
+echo "$CMD" > .cli_mode
+
 if tmux has-session -t president 2>/dev/null; then
   tmux send-keys -t president "$CMD" C-m
 else


### PR DESCRIPTION
## Summary
- record which CLI is running in `.cli_mode`
- skip Ctrl-C when using gemini so instructions propagate correctly
- document new behaviour in README

## Testing
- `bash -n agent-send.sh`
- `bash -n start_agents.sh`
- `bash -n launch_all.sh`
- `bash -n setup.sh`


------
https://chatgpt.com/codex/tasks/task_e_685f4f1f12cc832e938cd536d5c59721